### PR TITLE
Switch to OpenRouter API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+credentials

--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# BiAI
+
+This repository contains a minimal setup for a language learning Progressive Web App (PWA) and backend written in TypeScript. It serves as a starting point to test that the environment works before adding more features.
+
+## Requirements
+
+- Node.js with the TypeScript compiler (`tsc`).
+- Optional: Docker (for PostgreSQL and n8n services).
+- A `credentials` file in the project root to store environment variables (not committed to version control).
+
+## Setup
+
+1. **Install dependencies**
+
+   This project only relies on Node's built-in modules so no extra packages are required.
+
+2. **Build the TypeScript code**
+
+   ```bash
+   npm run build
+   ```
+
+3. **Run the server**
+
+   ```bash
+   npm start
+   ```
+
+   The server listens on port `3000` by default and calls the OpenRouter API when `/` is requested. The example PWA (`public/index.html`) fetches this endpoint to display the message from the selected model. Static files are available under `/public/`.
+   The raw response from OpenRouter is printed to the console for debugging.
+
+4. **Run tests**
+
+   ```bash
+   npm test
+   ```
+
+   The tests start the server, request the `/` route and verify that a response from the OpenRouter API (or fallback message) is returned.
+
+## Additional Services
+
+### PostgreSQL Database
+
+The example project does not require a database yet, but the following commands start a local PostgreSQL instance using Docker:
+
+```bash
+docker run --name biaipg -p 5432:5432 -e POSTGRES_PASSWORD=example -d postgres
+```
+
+Store your actual credentials in the `credentials` file and reference them from environment variables when you expand the application.
+
+### n8n Automation
+
+To experiment with n8n locally you can also use Docker:
+
+```bash
+docker run -it --name biai-n8n -p 5678:5678 n8nio/n8n
+```
+
+n8n can interact with this project over HTTP APIs. Add your n8n credentials or API keys to the `credentials` file and load them at runtime.
+
+## credentials file
+
+Create a file named `credentials` in the project root to store secrets such as database passwords or API tokens. For the OpenRouter integration, set `OPEN_ROUTER_KEY=<your key>` in this file and load it with a tool like `dotenv` or by exporting it before starting the server. This file is listed in `.gitignore` so it will not be committed to the repository.
+
+## Next steps
+
+- Replace the simple HTTP server with a framework of your choice (e.g., Express or Fastify) once you have package access.
+- Connect the backend to a database to store user progress.
+- Serve the PWA from the backend and integrate authentication.
+- Add a Telegram bot that communicates with the same backend to track progress across platforms.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "biai",
+  "version": "1.0.0",
+  "description": "Basic PWA backend in TypeScript",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "npm run build && node dist/test.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>BiAI Language Learning</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <h1>BiAI PWA</h1>
+  <p id="msg">Loading message...</p>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js');
+    }
+    fetch('/')
+      .then(r => r.text())
+      .then(t => document.getElementById('msg').textContent = t)
+      .catch(() => document.getElementById('msg').textContent = 'Failed to load message');
+  </script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "BiAI",
+  "short_name": "BiAI",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "BiAI language learning PWA"
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,7 @@
+self.addEventListener('install', event => {
+  self.skipWaiting();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(fetch(event.request));
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+import http from 'http';
+import https from 'https';
+import fs from 'fs';
+import path from 'path';
+
+async function fetchChatMessage(): Promise<string> {
+  const apiKey = process.env.OPEN_ROUTER_KEY;
+  if (!apiKey) {
+    return 'Missing OPEN_ROUTER_KEY';
+  }
+
+  const data = JSON.stringify({
+    model: 'deepseek-ai/deepseek-r1-0528',
+    messages: [{ role: 'user', content: 'Say hello to the world' }]
+  });
+
+  const options = {
+    hostname: 'openrouter.ai',
+    path: '/api/v1/chat/completions',
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Length': Buffer.byteLength(data)
+    }
+  };
+
+  return new Promise(resolve => {
+    const req = https.request(options, res => {
+      let body = '';
+      res.on('data', chunk => { body += chunk; });
+      res.on('end', () => {
+        console.log('OpenRouter raw response:', body);
+        try {
+          const json = JSON.parse(body);
+          const msg = json.choices?.[0]?.message?.content ?? 'No message';
+          resolve(msg.trim());
+        } catch (err) {
+          resolve('Failed to parse OpenRouter response');
+        }
+      });
+    });
+    req.on('error', () => resolve('Failed to reach OpenRouter'));
+    req.write(data);
+    req.end();
+  });
+}
+
+export function startServer(port: number) {
+  const server = http.createServer(async (req, res) => {
+    if (req.url === '/') {
+      const message = await fetchChatMessage();
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end(message);
+    } else if (req.url && req.url.startsWith('/public/')) {
+      const filePath = path.join(__dirname, '..', req.url);
+      fs.readFile(filePath, (err, data) => {
+        if (err) {
+          res.writeHead(404);
+          res.end();
+          return;
+        }
+        const ext = path.extname(filePath);
+        const contentType = ext === '.js' ? 'application/javascript' : ext === '.json' ? 'application/json' : 'text/html';
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(data);
+      });
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+
+  return server.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
+}
+
+if (require.main === module) {
+  const PORT = Number(process.env.PORT) || 3000;
+  startServer(PORT);
+}

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import http from 'http';
+import assert from 'assert';
+import { startServer } from './index';
+
+const PORT = 4000;
+
+const server = startServer(PORT);
+
+const options = {
+  hostname: 'localhost',
+  port: PORT,
+  path: '/',
+  method: 'GET'
+};
+
+const req = http.request(options, res => {
+  let data = '';
+  res.on('data', chunk => { data += chunk; });
+  res.on('end', () => {
+    server.close();
+    try {
+      assert.ok(data.length > 0);
+      console.log('Test passed');
+      process.exit(0);
+    } catch (err) {
+      console.error('Test failed');
+      process.exit(1);
+    }
+  });
+});
+
+req.on('error', err => {
+  server.close();
+  console.error('Test error', err);
+  process.exit(1);
+});
+
+req.end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- switch chat endpoint to OpenRouter and use `OPEN_ROUTER_KEY`
- update README to document OpenRouter usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844b90c0b048330b28a6a1a4da0c846