### PR TITLE
Add interactive evaluation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ n8n can interact with this project over HTTP APIs. Add your n8n credentials or A
 
 #### Sample workflow
 
-1. Start n8n and create a new workflow with an **HTTP Trigger** node. Set the method to `POST` and choose a path such as `/webhook/evaluate`.
-2. Add an **AI** or **HTTP Request** node that sends the incoming `language` and `objective` fields to your preferred model. Format the response as an array of questions and connect it back to a **Respond to Webhook** node. The workflow should return `{ "questions": ["...", "..."] }`.
-3. Create a second **HTTP Trigger** node on `/webhook/evaluate/finish` that receives the array of `answers`. Send these to the model to determine the level and connect the result to a **PostgreSQL** node to run `UPDATE user_languages SET actual_level=$1 WHERE username=$2`.
-4. Note the external URL of the first trigger and set `N8N_WEBHOOK_URL=<url>` in the `credentials` file so the server knows where to send evaluation requests.
+1. Start n8n and create a workflow with an **HTTP Trigger** node. This endpoint generates the quiz questions. Set the method to `POST` and choose a path such as `/webhook/evaluate`.
+2. Add an **AI** or **HTTP Request** node that sends the incoming `language` and `objective` fields to your preferred model. Format the response as JSON that contains the questions (with answers) and connect it back to a **Respond to Webhook** node.
+3. Create a second workflow with another **HTTP Trigger** node on `/webhook/evaluate/finish`. This receives the original quiz together with the user's answers and returns the detected level. Optionally update the database with a **PostgreSQL** node.
+4. Note the external URL of the first trigger and set `N8N_WEBHOOK_URL=<url>` in the `credentials` file. Set `N8N_GRADE_URL=<url>` to the second workflow so the server knows where to send answers for grading.
 
 ## credentials file
 

--- a/public/evaluate.html
+++ b/public/evaluate.html
@@ -12,15 +12,11 @@
   <div class="w-full max-w-md flex flex-col gap-4 p-4">
     <h1 class="text-center text-lg font-bold text-[#111818]">Level Evaluation</h1>
     <div id="question" class="min-h-[4rem] p-2"></div>
-    <form id="answerForm" class="flex flex-col gap-3">
-      <input id="answer" type="text" required placeholder="Your answer" class="form-input rounded-xl bg-[#f0f5f4] p-3 text-[#111818]" />
-      <button type="submit" class="bg-[#00a7a7] text-white rounded-full h-12 font-bold">Next</button>
-    </form>
+    <button id="next" class="bg-[#00a7a7] text-white rounded-full h-12 font-bold">Next</button>
   </div>
   <script>
     const questionEl = document.getElementById('question');
-    const form = document.getElementById('answerForm');
-    const input = document.getElementById('answer');
+    const nextBtn = document.getElementById('next');
     let questions = [];
     let answers = [];
     let index = 0;
@@ -29,30 +25,92 @@
       const res = await fetch('/evaluate/start');
       if (res.ok) {
         questions = await res.json();
-        showQuestion();
+        renderQuestion();
       } else {
         questionEl.textContent = 'Error loading questions';
+        nextBtn.disabled = true;
       }
     }
 
-    function showQuestion() {
-      if (index < questions.length) {
-        questionEl.textContent = questions[index];
-        input.value = '';
-        input.focus();
-      } else {
+    function renderQuestion() {
+      if (index >= questions.length) {
         submitAnswers();
+        return;
       }
+      const q = questions[index];
+      questionEl.innerHTML = '';
+      const text = document.createElement('p');
+      text.textContent = q.text;
+      text.className = 'mb-2';
+      questionEl.appendChild(text);
+      let inputEl;
+      if (q.type === 'multiple_choice') {
+        inputEl = document.createElement('div');
+        q.options.forEach(opt => {
+          const label = document.createElement('label');
+          label.className = 'flex items-center gap-2 mb-1';
+          const radio = document.createElement('input');
+          radio.type = 'radio';
+          radio.name = 'answer';
+          radio.value = opt;
+          label.appendChild(radio);
+          label.appendChild(document.createTextNode(opt));
+          inputEl.appendChild(label);
+        });
+      } else if (q.type === 'matching') {
+        inputEl = document.createElement('div');
+        const options = q.items.map(i => i.english);
+        q.items.forEach((item, i) => {
+          const row = document.createElement('div');
+          row.className = 'flex items-center gap-2 mb-2';
+          const span = document.createElement('span');
+          span.textContent = item.french;
+          const select = document.createElement('select');
+          select.dataset.index = String(i);
+          select.className = 'form-select rounded-xl bg-[#f0f5f4] p-2';
+          options.forEach(o => {
+            const op = document.createElement('option');
+            op.value = o;
+            op.textContent = o;
+            select.appendChild(op);
+          });
+          row.appendChild(span);
+          row.appendChild(select);
+          inputEl.appendChild(row);
+        });
+      } else {
+        inputEl = document.createElement('input');
+        inputEl.type = 'text';
+        inputEl.className = 'form-input rounded-xl bg-[#f0f5f4] p-3 w-full';
+      }
+      questionEl.appendChild(inputEl);
+      nextBtn.textContent = index === questions.length - 1 ? 'Submit' : 'Next';
     }
 
-    form.addEventListener('submit', e => {
-      e.preventDefault();
-      answers.push(input.value);
+    function collectAnswer() {
+      const q = questions[index];
+      let ans = '';
+      if (q.type === 'multiple_choice') {
+        const checked = questionEl.querySelector('input[name="answer"]:checked');
+        if (checked) ans = checked.value;
+      } else if (q.type === 'matching') {
+        const selects = questionEl.querySelectorAll('select');
+        const parts = [];
+        selects.forEach((s, i) => {
+          parts.push(q.items[i].french + ':' + (s as HTMLSelectElement).value);
+        });
+        ans = parts.join(',');
+      } else {
+        const input = questionEl.querySelector('input');
+        if (input) ans = (input as HTMLInputElement).value;
+      }
+      answers.push(ans);
       index++;
-      showQuestion();
-    });
+      renderQuestion();
+    }
 
     async function submitAnswers() {
+      nextBtn.disabled = true;
       const res = await fetch('/evaluate/finish', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -65,6 +123,7 @@
       }
     }
 
+    nextBtn.addEventListener('click', collectAnswer);
     loadQuestions();
   </script>
 </body>

--- a/public/home.html
+++ b/public/home.html
@@ -49,10 +49,11 @@
               <p class="text-base font-bold text-[#131615]">
                 Evaluate your level
               </p>
-              <p class="text-sm text-[#6c7f7c]">
+            <p class="text-sm text-[#6c7f7c]">
                 Take a quick test to assess your current proficiency
-              </p>
-            </div>
+            </p>
+            <a href="/evaluate" class="mt-2 inline-block bg-[#00a7a7] text-white rounded-full px-4 py-2 font-bold text-center">Start</a>
+          </div>
             <div
               class="w-full md:flex-1 aspect-video bg-cover bg-center rounded-xl"
               style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuBCBTyU53VCO_6fMnZWRJjYi8ZyDS6yEq7xJFjnUC_XTvgMHHOXD3R7iJohSrIvWpgruzgPTunk2OrdebDXtjTMfuuQcZlE-EouNfUsQQ-cH8VIo6kWQpnv0Zn-QUnP5domjAf1PNcLMT-9pO3W4FqWMSfUIKqxlq6o4do88x77ltveYg2OD_vgoODIidXP5698KleW5nmwZzxirSq6ty82aVVEcuHQdhahA4op8KAxbZn-iabggOf-C2b-xWd8Rwv-3v-ngCUuxnA')"

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -2,6 +2,89 @@
 import { Pool } from 'pg';
 import { getPool } from './db';
 
+// Types for the quiz structure returned by n8n
+export interface MultipleChoiceQuestion {
+  id: number;
+  type: 'multiple_choice';
+  text: string;
+  options: string[];
+  answer: string;
+  topic: string;
+  difficulty: string;
+}
+
+export interface FillInTheBlankQuestion {
+  id: number;
+  type: 'fill_in_the_blank';
+  text: string;
+  answer: string;
+  topic: string;
+  difficulty: string;
+}
+
+export interface ShortAnswerQuestion {
+  id: number;
+  type: 'short_answer';
+  text: string;
+  answer_keywords: string[];
+  topic: string;
+  difficulty: string;
+}
+
+export interface MatchingItem {
+  french: string;
+  english: string;
+}
+
+export interface MatchingQuestion {
+  id: number;
+  type: 'matching';
+  text: string;
+  items: MatchingItem[];
+  topic: string;
+  difficulty: string;
+}
+
+export type Question =
+  | MultipleChoiceQuestion
+  | FillInTheBlankQuestion
+  | ShortAnswerQuestion
+  | MatchingQuestion;
+
+export interface Quiz {
+  questions: Question[];
+}
+
+// Raw payload shape from n8n
+type RawN8nOutput = Array<{ output: string }>;
+
+/**
+ * Cleans the output coming from the n8n node, stripping markdown fences
+ * and parsing the inner JSON.
+ */
+export function cleanN8nOutput(raw: RawN8nOutput): Quiz {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    throw new Error('Invalid input: expected a non-empty array');
+  }
+
+  const first = raw[0].output;
+  const fencedMatch = first.match(/```json\s*([\s\S]*?)\s*```/i);
+  const jsonText = fencedMatch ? fencedMatch[1] : first;
+
+  try {
+    const parsed = JSON.parse(jsonText) as Quiz;
+    if (!parsed.questions || !Array.isArray(parsed.questions)) {
+      throw new Error('Parsed object does not contain a questions array');
+    }
+    return parsed;
+  } catch (err) {
+    console.error('Failed to parse n8n output:', err, '\nRaw text:', jsonText);
+    throw new Error('Could not clean/parse n8n output JSON');
+  }
+}
+
+const quizzes: Map<string, Quiz> = new Map();
+
 let pool: Pool | null = null;
 
 async function ensurePool() {
@@ -25,7 +108,7 @@ export async function getPrefs(username: string) {
   return null;
 }
 
-export async function startEvaluation(username: string): Promise<string[] | null> {
+export async function startEvaluation(username: string): Promise<Question[] | null> {
   const prefs = await getPrefs(username);
   if (!prefs || !process.env.N8N_WEBHOOK_URL) {
     return null;
@@ -37,8 +120,14 @@ export async function startEvaluation(username: string): Promise<string[] | null
       body: JSON.stringify({ language: prefs.language, objective: prefs.objective })
     });
     if (!res.ok) return null;
-    const data = await res.json();
-    return Array.isArray(data.questions) ? data.questions : null;
+    const raw = await res.json();
+    const quiz = cleanN8nOutput(raw);
+    quizzes.set(username, quiz);
+    const questionsForUser = quiz.questions.map(q => {
+      const { answer, answer_keywords, ...rest } = q as any;
+      return rest;
+    });
+    return questionsForUser;
   } catch (err) {
     console.error('startEvaluation error:', err.message);
     return null;
@@ -46,12 +135,14 @@ export async function startEvaluation(username: string): Promise<string[] | null
 }
 
 export async function finishEvaluation(username: string, answers: string[]): Promise<boolean> {
-  if (!process.env.N8N_WEBHOOK_URL) return false;
+  const quiz = quizzes.get(username);
+  quizzes.delete(username);
+  if (!quiz || !process.env.N8N_GRADE_URL) return false;
   try {
-    const res = await fetch(process.env.N8N_WEBHOOK_URL, {
+    const res = await fetch(process.env.N8N_GRADE_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, answers })
+      body: JSON.stringify({ username, quiz, answers })
     });
     if (!res.ok) return false;
     const data = await res.json();


### PR DESCRIPTION
## Summary
- link to evaluation from the homepage
- show quiz questions one-by-one with radio/select/inputs

## Testing
- `npm install pg-mem`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aaadf307483309a2d3dce80bd96c1