### PR TITLE
Update DB code to match latest schema

### DIFF
--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -98,7 +98,13 @@ export async function getPrefs(username: string) {
   const p = await ensurePool();
   if (!p) return null;
   try {
-    const res = await p.query('SELECT language, objective FROM user_languages WHERE username = $1', [username]);
+    const res = await p.query(
+      `SELECT l.code AS language, ul.objective
+       FROM user_languages ul
+       JOIN languages l ON ul.language_id = l.id
+       WHERE ul.username = $1`,
+      [username]
+    );
     if (res.rowCount > 0) {
       return res.rows[0];
     }

--- a/src/firstLogin.ts
+++ b/src/firstLogin.ts
@@ -16,13 +16,29 @@ export async function saveUserPrefs(
     return false;
   }
   try {
+    // Ensure language exists and get its id
+    const langRes = await pool.query(
+      'SELECT id FROM languages WHERE code = $1',
+      [language]
+    );
+    let languageId: number;
+    if (langRes.rowCount > 0) {
+      languageId = langRes.rows[0].id;
+    } else {
+      const insertLang = await pool.query(
+        'INSERT INTO languages (code, name) VALUES ($1, $2) RETURNING id',
+        [language, language]
+      );
+      languageId = insertLang.rows[0].id;
+    }
+
     const result = await pool.query(
-      `INSERT INTO user_languages (username, language, objective, actual_level)
+      `INSERT INTO user_languages (username, objective, actual_level, language_id)
        VALUES ($1, $2, $3, $4)
        ON CONFLICT (username)
-         DO UPDATE SET language = EXCLUDED.language,
-                       objective = EXCLUDED.objective`,
-      [username, language, objective, 'beginner']
+         DO UPDATE SET objective = EXCLUDED.objective,
+                       language_id = EXCLUDED.language_id`,
+      [username, objective, 'beginner', languageId]
     );
     return result.rowCount > 0;
   } catch (err: any) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -29,11 +29,17 @@ dbServer.listen(DB_PORT, 'localhost', () => {
     email text,
     telegram_id text
   );
+  CREATE TABLE languages (
+    id serial primary key,
+    code text unique,
+    name text,
+    created_at timestamp with time zone default now()
+  );
   CREATE TABLE user_languages (
     username text primary key references users(username),
-    language text,
     objective text,
-    actual_level text
+    actual_level text,
+    language_id integer references languages(id)
   );`);
   const pg = mem.adapters.createPg();
   (require as any).cache[require.resolve('pg')] = { exports: pg };


### PR DESCRIPTION
## Summary
- adjust `saveUserPrefs` to store language via new `languages` table
- fetch language code when starting evaluation
- adapt integration tests to new schema

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684acec908608330aaa36cc3a5078858